### PR TITLE
support CellCollective format

### DIFF
--- a/StableMotifs/Format.py
+++ b/StableMotifs/Format.py
@@ -270,6 +270,7 @@ def import_primes(fname, format='BooleanNet', remove_constants=False):
             lines[i] = lines[i] + ' = ' + lines[i]
         rules2 = "\n".join(lines)
         rules = rules1 + "\n" + rules2
+        rules = cellcollective2bnet(rules)
 
     else:
         rules = remove_comment_lines(open(fname))


### PR DESCRIPTION
#48 

In Format.py
- Created cellcollective2bnet() which converts CellCollective format into Bnet format.

- Modified import_primes()
when the format is 'CellCollective',
it loads external_components.ALL.txt and makes new rules in the form "A = A" for each node.
then they are merged with rules from expressions.All.txt